### PR TITLE
Add a travis setting and docker-compose file to make compiling easy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+
+language: generic
+
+sudo: required
+
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_COMPOSE_VERSION=1.24.0
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+install:
+  - docker-compose pull satysfi slim
+  - docker-compose build satysfi slim
+
+script:
+  - git clone https://github.com/gfngfn/SATySFi.git
+  - docker-compose up --abort-on-container-exit build-demo
+  - docker-compose up --abort-on-container-exit build-demo-slim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.2'
+services:
+  satysfi:
+    image: amutake/satysfi:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      cache_from:
+        - amutake/satysfi:latest
+  slim:
+    image: amutake/satysfi:slim
+    build:
+      context: .
+      dockerfile: ./Dockerfile.slim
+      cache_from:
+        - amutake/satysfi:slim
+  build-demo:
+    image: amutake/satysfi:latest
+    user: opam
+    volumes:
+       - ./SATySFi/demo:/home/opam/satysfi
+    entrypoint:
+       - sudo
+       - docker-entrypoint.sh
+       - satysfi
+       - demo.saty
+  build-demo-slim:
+    image: amutake/satysfi:slim
+    volumes:
+       - ./SATySFi/demo:/satysfi
+    entrypoint:
+       - satysfi
+       - demo.saty


### PR DESCRIPTION
I add a [Travis CI](https://travis-ci.org/) setting file. And for the easy compiling, I add a `docker-compose.yml` too. You can check the following things for each commit after merge this PR:

1. Can `Dockerfile` and `Dockerfile.slim` be compiled successfully or not
2. Can two images: `satysfi:latest` and `satysfi:slim` compile [demo.saty](https://github.com/gfngfn/SATySFi/blob/master/demo/demo.saty) or not

### Sample result

https://travis-ci.org/y-yu/satysfi-docker/jobs/520026708