### PR TITLE
Rename satysfi-lib-dist to satysfi-dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 
 # Setup SATySFi & Satyrographos
 RUN opam update
-RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-lib-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
-RUN opam install satysfi.${SATYSFI_VERSION} satysfi-lib-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
+RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
+RUN opam install satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
 RUN opam config exec -- satyrographos install
 
 # Setup build directory

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -6,8 +6,8 @@ ENV SATYROGRAPHOS_VERSION=0.0.2.1
 
 # Setup SATySFi & Satyrographos
 RUN opam update
-RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-lib-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
-RUN opam install satysfi.${SATYSFI_VERSION} satysfi-lib-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
+RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
+RUN opam install satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
 RUN eval $(opam env) && \
   satyrographos install -copy && \
   cp $(which satysfi) / && \


### PR DESCRIPTION
From the next release, use `satysfi-dist` instead of `satysfi-lib-dist`.

cf. https://github.com/na4zagin3/satyrographos-repo/issues/32