### PR TITLE
Fix IPAexfont version in download-fonts.sh (temporary patch)

### DIFF
--- a/Dockerfile.head
+++ b/Dockerfile.head
@@ -19,6 +19,8 @@ WORKDIR /root/SATySFi
 RUN opam pin add --no-action --kind local satysfi .
 RUN opam depext satysfi
 RUN opam install satysfi
+# The below patch will be removed after SATySFi#228 is merged.
+RUN sed -i -e "s!IPAexfont00301!IPAexfont00401!g" download-fonts.sh
 RUN ./download-fonts.sh
 RUN sed -i -e "s!/usr/local/share!$(opam var share)!" install-libs.sh
 RUN ./install-libs.sh $(opam var share)/satysfi


### PR DESCRIPTION
This PR fixes nightly build (and also CI workflow).

I will revert this commit after https://github.com/gfngfn/SATySFi/pull/228 is merged.