### PR TITLE
Fix nightly build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 # TODO: add `org.opencontainers.image.ref.name` (but what is this?)
 
 # Setup SATySFi & Satyrographos
+RUN apt-get update
 RUN opam update
 RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
 RUN opam install satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}

--- a/Dockerfile.head
+++ b/Dockerfile.head
@@ -1,5 +1,6 @@
 FROM amutake/satysfi-base:opam-2.0.6-ocaml-4.10.0 AS build-env
 
+RUN apt-get update
 RUN opam update
 
 # Install Satyrographos

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -5,6 +5,7 @@ ENV SATYSFI_VERSION=0.0.5+dev2020.09.05
 ENV SATYROGRAPHOS_VERSION=0.0.2.6
 
 # Setup SATySFi & Satyrographos
+RUN apt-get update
 RUN opam update
 RUN opam depext satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}
 RUN opam install satysfi.${SATYSFI_VERSION} satysfi-dist.${SATYSFI_VERSION} satyrographos.${SATYROGRAPHOS_VERSION}


### PR DESCRIPTION
https://github.com/amutake/satysfi-docker/runs/1361339081?check_suite_focus=true

```
Step 6/31 : RUN opam depext satyrographos
 ---> Running in 9da91059b875
# Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=ubuntu, os-family=debian
# The following system packages are needed:
m4
pkg-config
# The following new OS packages need to be installed: pkg-config
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpgconf_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/dirmngr_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gnupg-l10n_2.2.4-1ubuntu1.2_all.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gnupg-utils_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpg_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpg-agent_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpg-wks-client_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpg-wks-server_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gpgsm_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gnupg2/gnupg_2.2.4-1ubuntu1.2_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
OS package installation failed
The command '/bin/sh -c opam depext satyrographos' returned a non-zero code: 1
```